### PR TITLE
Pass Twitter error description correctly to class

### DIFF
--- a/src/Twitter.php
+++ b/src/Twitter.php
@@ -158,7 +158,7 @@ class Twitter extends AbstractProvider
             return;
         }
 
-        $error = $data['description'] ?? '';
+        $error = $data['error_description'] ?? '';
         $code = $data['code'] ?? $response->getStatusCode();
 
         throw new IdentityProviderException($error, $code, $data);


### PR DESCRIPTION
Apparently twitter returns the error description in the key `error_description`, not in `description`