### PR TITLE
PHP 8.4 Implicitly nullable parameters deprecated

### DIFF
--- a/src/Twitter.php
+++ b/src/Twitter.php
@@ -235,7 +235,7 @@ class Twitter extends AbstractProvider
      * @param string $passed_verifier Verifier string to use. Defaults to $this->getPkceVerifier().
      * @return string
      */
-    public function generatePkceChallenge(string $passed_verifier = null): string
+    public function generatePkceChallenge(?string $passed_verifier = null): string
     {
         $verifier = $passed_verifier ?? $this->getPkceVerifier();
         return $this->base64Urlencode(hash('SHA256', $verifier, true));


### PR DESCRIPTION
From PHP.net 8.4 release notes https://www.php.net/releases/8.4/en.php#deprecations_and_bc_breaks :

- Implicitly nullable parameter types are now deprecated.

More info: https://wiki.php.net/rfc/deprecate-implicitly-nullable-types